### PR TITLE
Add organization type to registration and yak shaving for the greater good

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ group :development, :test do
   gem 'assert_difference'
   gem 'selenium-webdriver'
   gem 'faker'
+end
+
+group :test do
   gem 'webmock'
   gem 'vcr'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development, :test do
   gem 'database_cleaner',   '~> 1.4.0'
   gem 'mocha',              '~> 1.1.0'
   gem 'assert_difference'
-  gem 'selenium-webdriver'
+  gem 'poltergeist'
   gem 'faker'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,5 +54,4 @@ end
 
 group :test do
   gem 'webmock'
-  gem 'vcr'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    vcr (2.9.3)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.1.2)
@@ -330,7 +329,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
-  vcr
   web-console (~> 2.0)
   webmock
   will_paginate (~> 3.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,12 +73,11 @@ GEM
     capybara-screenshot (1.0.9)
       capybara (>= 1.0, < 3)
       launchy
-    childprocess (0.5.6)
-      ffi (~> 1.0, >= 1.0.11)
     city-state (0.0.13)
       rubyzip (~> 1.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
+    cliver (0.3.2)
     cocaine (0.5.7)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
@@ -114,7 +113,6 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
-    ffi (1.9.8)
     figaro (1.1.1)
       thor (~> 0.14)
     geocoder (1.2.8)
@@ -154,6 +152,11 @@ GEM
       cocaine (~> 0.5.3)
       mime-types
     pg (0.18.1)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -233,11 +236,6 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    selenium-webdriver (2.44.0)
-      childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simplecov (0.10.0)
@@ -277,7 +275,9 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    websocket (1.2.2)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -313,6 +313,7 @@ DEPENDENCIES
   modernizr-rails
   paperclip (~> 4.2.1)
   pg
+  poltergeist
   pry
   puma
   quiet_assets
@@ -322,7 +323,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  selenium-webdriver
   shoulda-matchers
   simplecov
   spring

--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -1,0 +1,18 @@
+$(document).ready(function(){
+  $('#org_type').change(function() {
+    if($(this).val() === 'Other') {
+      $('#org_type_other').fadeIn();
+    } else {
+      $('#org_type_other').fadeOut();
+    }
+  });
+
+  $('.registration-submit').click(function(){
+    if($('#org_type').val() === 'Other') {
+      var org_type = $('#organization_type_other').val();
+    } else {
+      var org_type = $('#org_type').val();
+    }
+    $('#company_organization_type').val(org_type);
+  });
+});

--- a/app/assets/javascripts/static_application.js
+++ b/app/assets/javascripts/static_application.js
@@ -2,3 +2,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require company
+//= require registration

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -23,3 +23,7 @@ div.error {
 input.error, select.error, textarea.error {
   border-color: #fdc7c7;
 }
+
+#org_type_other {
+    display: none;
+}

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -4,6 +4,7 @@ class CompaniesController < ApplicationController
 
   def new
     @company = Company.new
+    @registration = RegistrationPresenter.new
   end
 
   def show

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -28,7 +28,7 @@ class CompaniesController < ApplicationController
   private
 
   def company_params
-    cp = params.require(:company).permit(:name,:organization,:title,:state,:city,:zip_code,:email)
+    cp = params.require(:company).permit(:name,:organization,:title,:state,:city,:zip_code,:email, :organization_type)
     if params[:company][:hiring] == "1"
       cp.merge(hiring: true, hire_count: params[:company][:hire_count].to_i)
     else

--- a/app/presenters/registration_presenter.rb
+++ b/app/presenters/registration_presenter.rb
@@ -1,0 +1,11 @@
+class RegistrationPresenter
+  def organization_types
+    [
+      "Employer",
+      "Training Institution",
+      "Government",
+      "Interested Individual",
+      "Other"
+    ]
+  end
+end

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -12,9 +12,9 @@
       <div class="signup-errors">
         <p>Sorry, we had problems processing that information. Please fix the following issues:</p>
         <ul>
-        <% @company.errors.each do |field, message| %>
-          <li><strong><%= field %>: </strong><span><%= message%></span></li>
-        <% end %>
+          <% @company.errors.each do |field, message| %>
+            <li><strong><%= field %>: </strong><span><%= message%></span></li>
+          <% end %>
         </ul>
       </div>
     <% end %>
@@ -29,9 +29,17 @@
       <%= f.text_field :organization, required: true  %>
     </div>
 
-    <div class="row">
-      <%= f.label(:organization_type, "Organization Type") %>
-      <%= select_tag "organization_type", options_for_select(@registration.organization_types) %>
+    <div class="row cols-75-25">
+      <div class="col">
+        <%= f.label(:organization_type, "Organization Type (select one)") %>
+        <%= select_tag "organization_type", options_for_select(@registration.organization_types), id: "org_type" %>
+      </div>
+
+      <div class="col" id="org_type_other">
+        <%= f.label(:organization_type_other, "Enter:") %>
+        <%= text_field_tag :organization_type_other, "",required: true  %>
+        <%= f.hidden_field :organization_type %>
+      </div>
     </div>
 
     <div class="row">
@@ -69,7 +77,7 @@
     </div>
 
     <div class="row button-center">
-      <%= f.submit "Sign Up", class: 'button' %>
+      <%= f.submit "Sign Up", class: 'button registration-submit' %>
     </div>
 
   <script>

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -30,6 +30,11 @@
     </div>
 
     <div class="row">
+      <%= f.label(:organization_type, "Organization Type") %>
+      <%= select_tag "organization_type", options_for_select(@registration.organization_types) %>
+    </div>
+
+    <div class="row">
       <%= f.label(:title, "Your Title") %>
       <%= f.text_field :title, required: true  %>
     </div>

--- a/spec/features/guest_user_spec.rb
+++ b/spec/features/guest_user_spec.rb
@@ -55,22 +55,36 @@ RSpec.feature "Company Signup Page", type: :feature do
       find_button("Sign Up")
     end
 
-    it "can signup their company using the signup form and a standard organization type" do
-      visit signup_path
-      within("#new_company") do
-        fill_in 'company[name]', with: "Bob"
-        fill_in 'company[organization]', with: "Google"
-        select 'Interested Individual', from: 'organization_type'
-        fill_in 'company[title]', with: "RoR Developer"
-        fill_in 'company[city]', with: "Denver"
-        select('Colorado', from: 'company[state]')
-        fill_in 'company[zip_code]', with: "80001"
-        fill_in 'company[email]', with: "google@email.com"
-        check 'company[hiring]'
-        fill_in 'company[hire_count]', with: 5
-        click_button('Sign Up')
+    context "valid signup information" do
+      before :each do
+        visit signup_path
+        within("#new_company") do
+          fill_in 'company[name]', with: "Bob"
+          fill_in 'company[organization]', with: "Google"
+          fill_in 'company[title]', with: "RoR Developer"
+          fill_in 'company[city]', with: "Denver"
+          select('Colorado', from: 'company[state]')
+          fill_in 'company[zip_code]', with: "80001"
+          fill_in 'company[email]', with: "google@email.com"
+          check 'company[hiring]'
+          fill_in 'company[hire_count]', with: 5
+        end
       end
-      expect(page).to have_content("Thanks for registering!")
+
+      it "can signup their company using the signup form and a standard organization type" do
+        select 'Interested Individual', from: 'organization_type'
+        click_button('Sign Up')
+        expect(page).to have_content("Thanks for registering!")
+      end
+
+      it "can signup their company using the signup form and a custom organization type", js: true do
+        select 'Other', from: 'organization_type'
+        fill_in 'organization_type_other', with: 'After School Club'
+
+        expect{ click_button('Sign Up') }.to change { Company.count }.by(1)
+        expect(Company.last.organization_type).to eq('After School Club')
+        expect(page).to have_content("Thanks for registering!")
+      end
     end
 
     it "can not signup a company if email validation fails", js: true do

--- a/spec/features/guest_user_spec.rb
+++ b/spec/features/guest_user_spec.rb
@@ -55,11 +55,12 @@ RSpec.feature "Company Signup Page", type: :feature do
       find_button("Sign Up")
     end
 
-    it "can signup their company using the signup form" do
+    it "can signup their company using the signup form and a standard organization type" do
       visit signup_path
       within("#new_company") do
         fill_in 'company[name]', with: "Bob"
         fill_in 'company[organization]', with: "Google"
+        select 'Interested Individual', from: 'organization_type'
         fill_in 'company[title]', with: "RoR Developer"
         fill_in 'company[city]', with: "Denver"
         select('Colorado', from: 'company[state]')

--- a/spec/features/guest_user_spec.rb
+++ b/spec/features/guest_user_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Company Signup Page", type: :feature do
       expect(page).to have_content("Thanks for registering!")
     end
 
-    it "can not signup a company if email validation fails" do
+    it "can not signup a company if email validation fails", js: true do
       visit ('/signup')
       within("#new_company") do
         fill_in 'company[name]', with: "Bob"
@@ -87,9 +87,9 @@ RSpec.feature "Company Signup Page", type: :feature do
         fill_in 'company[hire_count]', with: 5
         click_button('Sign Up')
       end
-      expect(current_path).to eq(companies_path)
 
-      expect(page.find('.signup-errors')).to have_content("Sorry, we had problems processing that information. Please fix the following issues: email: is invalid")
+      expect(current_path).to eq(signup_path)
+      expect(page).to have_content("Please enter a valid email address.")
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -31,16 +31,19 @@ RSpec.describe Company, type: :model do
   end
 
   it "should count the number of companies by status" do
-    10.times do |i|
-      create(:company, email: "company#{i}@example.com")
-    end
-    expect(Company.company_count_by_status("uncontacted")).to eq(10)
+    expect{
+      10.times do |i|
+        create(:company, email: "company#{i}@example.com")
+      end
+    }.to change {
+      Company.company_count_by_status("uncontacted")
+    }.by(10)
   end
 
   it "should count order the cities by the number of companies" do
     10.times do |i|
       create(:company, email: "company#{i}@example.com")
     end
-    expect(Company.company_count_by_city).to eq([["Denver",10]])
+    expect(Company.company_count_by_city).to eq([["Denver", 10]])
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,9 +16,29 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.include AssertDifference
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
 end
 
 WebMock.disable_net_connect!(:allow_localhost => true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require 'capybara/rspec'
 require 'factory_girl_rails'
 require 'support/factory_girl'
 require 'capybara-screenshot/rspec'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,3 +17,5 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include AssertDifference
 end
+
+WebMock.disable_net_connect!(:allow_localhost => true)


### PR DESCRIPTION
The real purpose of this PR:
- Allow registration to accept an organization type.

Some yaks that were shaved:
- Add `RegistrationPresenter`. We can likely move more code here.
- Add Poltergeist to allow tests to run JS.
- Add DatabaseCleaner and configure to properly work with tests using JS.
- Configure WebMock to allow HTTP traffic to localhost but not the outside world to prevent accidentally exceeding API limits.
- Fix email validation guest user spec that wasn't actually testing the JS.
